### PR TITLE
use latest stable Debian image for Prometheus

### DIFF
--- a/prometheus/egg-prometheus.json
+++ b/prometheus/egg-prometheus.json
@@ -1,45 +1,35 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-02T14:38:06+00:00",
+    "exported_at": "2025-09-14T13:11:04+00:00",
     "name": "Prometheus",
     "author": "p.zarrad@outlook.de",
     "uuid": "ff786432-4746-48ad-8212-71a266529aa9",
     "description": "The Prometheus monitoring system and time series database.",
-    "features": null,
+    "tags": [],
+    "features": [],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io/parkervcp/yolks:debian": "ghcr.io/parkervcp/yolks:debian"
     },
     "file_denylist": [],
-    "startup": ".\/prometheus --web.listen-address=0.0.0.0:{{SERVER_PORT}} --config.file=\/home\/container\/prometheus.yml --storage.tsdb.path=\/home\/container\/data --web.console.templates=\/home\/container\/consoles --web.console.libraries=\/home\/container\/console_libraries --web.config.file=\/home\/container\/prometheus.web.yml --storage.tsdb.retention.time={{DATA_SAVE_TIME}}",
+    "startup": "./prometheus --web.listen-address=0.0.0.0:{{SERVER_PORT}} --config.file=/home/container/prometheus.yml --storage.tsdb.path=/home/container/data --web.console.templates=/home/container/consoles --web.console.libraries=/home/container/console_libraries --web.config.file=/home/container/prometheus.web.yml --storage.tsdb.retention.time={{DATA_SAVE_TIME}}",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Server is ready to receive web requests.\"\r\n}",
+        "startup": "{\n    \"done\": \"Server is ready to receive web requests.\"\n}",
         "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/sh\r\nshopt -s extglob\r\n# Switch to mounted directory\r\ncd \/mnt\/server\r\n# Update installation system and install curl\r\napt-get update\r\napt-get install -y curl\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"amd64\" || echo \"arm64\")\r\n# Cleanup previous install if available\r\nif [ -f \"prometheus.yml\" ]; then mv prometheus.yml prometheus.yml.bak; fi\r\nif [ -f \"prometheus.web.yml\" ]; then mv prometheus.web.yml prometheus.web.yml.bak; fi\r\nrm -rfv !(data|prometheus.yml.bak|prometheus.web.yml.bak)\r\n# Download and extract Prometheus\r\nversion=${PROMETHEUS_VERSION}\r\nif [ \"$version\" = \"latest\" ]; then version=$(curl --silent \"https:\/\/api.github.com\/repos\/prometheus\/prometheus\/releases\/latest\" | grep '\"tag_name\":' | sed -E 's\/.*\"([^\"]+)\".*\/\\1\/' | cut -c2-); fi\r\ncurl -L https:\/\/github.com\/prometheus\/prometheus\/releases\/download\/v${version}\/prometheus-${version}.linux-${ARCH}.tar.gz --output prometheus.tar.gz\r\ntar -zxvf prometheus.tar.gz\r\nmv -n prometheus-*\/* .\/\r\nrm -rf prometheus.tar.gz prometheus-*\/\r\n# Restore configuration if necessary\r\nif [ -f \"prometheus.yml.bak\" ]; then rm -rf prometheus.yml && mv prometheus.yml.bak prometheus.yml && rm -rf prometheus.yml.bak; fi\r\nif [ -f \"prometheus.web.yml.bak\" ]; then rm -rf prometheus.web.yml && mv prometheus.web.yml.bak prometheus.web.yml && rm -rf prometheus.web.yml.bak; fi\r\n# Create dummy prometheus.web.yml as a placeholder\r\nif [ ! -f \"prometheus.web.yml\" ]; then touch prometheus.web.yml; fi",
-            "container": "debian:buster-slim",
+            "script": "#!/bin/sh\r\nshopt -s extglob\r\n# Switch to mounted directory\r\ncd /mnt/server\r\n# Update installation system and install curl\r\napt-get update\r\napt-get install -y curl\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"amd64\" || echo \"arm64\")\r\n# Cleanup previous install if available\r\nif [ -f \"prometheus.yml\" ]; then mv prometheus.yml prometheus.yml.bak; fi\r\nif [ -f \"prometheus.web.yml\" ]; then mv prometheus.web.yml prometheus.web.yml.bak; fi\r\nrm -rfv !(data|prometheus.yml.bak|prometheus.web.yml.bak)\r\n# Download and extract Prometheus\r\nversion=${PROMETHEUS_VERSION}\r\nif [ \"$version\" = \"latest\" ]; then version=$(curl --silent \"https://api.github.com/repos/prometheus/prometheus/releases/latest\" | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\\1/' | cut -c2-); fi\r\ncurl -L https://github.com/prometheus/prometheus/releases/download/v${version}/prometheus-${version}.linux-${ARCH}.tar.gz --output prometheus.tar.gz\r\ntar -zxvf prometheus.tar.gz\r\nmv -n prometheus-*/* ./\r\nrm -rf prometheus.tar.gz prometheus-*/\r\n# Restore configuration if necessary\r\nif [ -f \"prometheus.yml.bak\" ]; then rm -rf prometheus.yml && mv prometheus.yml.bak prometheus.yml && rm -rf prometheus.yml.bak; fi\r\nif [ -f \"prometheus.web.yml.bak\" ]; then rm -rf prometheus.web.yml && mv prometheus.web.yml.bak prometheus.web.yml && rm -rf prometheus.web.yml.bak; fi\r\n# Create dummy prometheus.web.yml as a placeholder\r\nif [ ! -f \"prometheus.web.yml\" ]; then touch prometheus.web.yml; fi",
+            "container": "debian:trixie-slim",
             "entrypoint": "bash"
         }
     },
     "variables": [
-        {
-            "name": "Prometheus Version",
-            "description": "The version of Prometheus to install. By default the latest version is being installed.",
-            "env_variable": "PROMETHEUS_VERSION",
-            "default_value": "latest",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|max:20",
-            "sort": null,
-            "field_type": "text"
-        },
         {
             "name": "Data Save time in Days",
             "description": "How long the data is being saved",
@@ -47,9 +37,26 @@
             "default_value": "15d",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:10",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:10"
+            ],
+            "sort": 1
+        },
+        {
+            "name": "Prometheus Version",
+            "description": "The version of Prometheus to install. By default the latest version is being installed.",
+            "env_variable": "PROMETHEUS_VERSION",
+            "default_value": "latest",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:20"
+            ],
+            "sort": 2
         }
     ]
 }


### PR DESCRIPTION
`debian:buster-slim` has reached end of support.  
Installation throws the following error:
```
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```
Installation script works fine on latest stable Debian release: `trixie-slim`.

Changing the docker image is the only change that has been done.
But as requested, the change has been done through the panel, then exported.
This caused the script to update from `PTDL_v2` to `PLCN_v2`, causing a lot of changes.

# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel

